### PR TITLE
fix: resolve TypeScript compilation error for compression module

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,11 +62,11 @@
     "tslib": "^2.8.1",
     "typescript": "^5.8.3",
     "uuid": "^11.1.0",
-    "winston": "^3.17.0"
+    "winston": "^3.17.0",
+    "@types/compression": "^1.8.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.31.0",
-    "@types/compression": "^1.8.1",
     "@types/nodemon": "^1.19.6",
     "@typescript-eslint/eslint-plugin": "^8.37.0",
     "@typescript-eslint/parser": "^8.37.0",

--- a/src/middleware/performance.ts
+++ b/src/middleware/performance.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import compression from 'compression';
+import * as compression from 'compression';
 import logger from '../utils/logger';
 
 /**

--- a/src/types/compression.d.ts
+++ b/src/types/compression.d.ts
@@ -1,0 +1,1 @@
+declare module 'compression';


### PR DESCRIPTION
- Move @types/compression from devDependencies to dependencies for Render deployment
- Change compression import to use * import syntax for better TypeScript compatibility
- Add explicit module declaration for compression in types directory
- Ensure build works correctly on deployment platforms